### PR TITLE
Fixed version check to allow multi-digit versions

### DIFF
--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -35,7 +35,7 @@ if [ -z "$1" ]; then
 else
     echo "Application Name : $1"
 fi
-if [[ "$2" == [0-9].[0-9].[0-9] ]]; then
+if [[ "$2" =~ [0-9]+.[0-9]+.[0-9]+ ]]; then
     echo "Application Version : $2"
 else
     echo "Please enter a valid version for your application (fromat [0-9].[0-9].[0-9])"


### PR DESCRIPTION
The version check did not accept multi-digit versions such as: 1.30.12.  This PR uses a regular express to check versions allowing one or more digit in each component of the version.