### PR TITLE
Added Ability To Run Script From Any Location

### DIFF
--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -167,7 +167,7 @@ function createInstaller() {
     while true; do
         read -p "Do you wish to sign the installer (You should have Apple Developer Certificate) [y/N]?" answer
         [[ $answer == "y" || $answer == "Y" ]] && FLAG=true && break
-        [[ $answer == "n" || $answer == "N" || $answer == "" ]] && log_info "Skiped signing process." && FLAG=false && break
+        [[ $answer == "n" || $answer == "N" || $answer == "" ]] && log_info "Skipped signing process." && FLAG=false && break
         echo "Please answer with 'y' or 'n'"
     done
     [[ $FLAG == "true" ]] && signProduct ${PRODUCT}-macos-installer-x64-${VERSION}.pkg

--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -12,7 +12,7 @@ TIME=`date +%H:%M:%S`
 LOG_PREFIX="[$DATE $TIME]"
 
 function printSignature() {
-  cat $SCRIPTPATH/utils/ascii_art.txt
+  cat "$SCRIPTPATH/utils/ascii_art.txt"
   echo
 }
 
@@ -131,7 +131,7 @@ copyBuildDirectory() {
 }
 
 function buildPackage() {
-    log_info "Apllication installer package building started.(1/3)"
+    log_info "Application installer package building started.(1/3)"
     pkgbuild --identifier "org.${PRODUCT}.${VERSION}" \
     --version "${VERSION}" \
     --scripts "${TARGET_DIRECTORY}/darwin/scripts" \

--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -47,7 +47,7 @@ fi
 if [[ "$2" =~ [0-9]+.[0-9]+.[0-9]+ ]]; then
     echo "Application Version : $2"
 else
-    echo "Please enter a valid version for your application (fromat [0-9].[0-9].[0-9])"
+    echo "Please enter a valid version for your application (format [0-9].[0-9].[0-9])"
     echo
     printUsage
     exit 1

--- a/macOS-x64/build-macos-x64.sh
+++ b/macOS-x64/build-macos-x64.sh
@@ -72,7 +72,7 @@ log_error() {
 
 deleteInstallationDirectory() {
     log_info "Cleaning $TARGET_DIRECTORY directory."
-    rm -rf $TARGET_DIRECTORY
+    rm -rf "$TARGET_DIRECTORY"
 
     if [[ $? != 0 ]]; then
         log_error "Failed to clean $TARGET_DIRECTORY directory" $?
@@ -81,10 +81,10 @@ deleteInstallationDirectory() {
 }
 
 createInstallationDirectory() {
-    if [ -d ${TARGET_DIRECTORY} ]; then
+    if [ -d "${TARGET_DIRECTORY}" ]; then
         deleteInstallationDirectory
     fi
-    mkdir $TARGET_DIRECTORY
+    mkdir -pv "$TARGET_DIRECTORY"
 
     if [[ $? != 0 ]]; then
         log_error "Failed to create $TARGET_DIRECTORY directory" $?
@@ -94,70 +94,70 @@ createInstallationDirectory() {
 
 copyDarwinDirectory(){
   createInstallationDirectory
-  cp -r $SCRIPTPATH/darwin ${TARGET_DIRECTORY}/
-  chmod -R 755 ${TARGET_DIRECTORY}/darwin/scripts
-  chmod -R 755 ${TARGET_DIRECTORY}/darwin/Resources
-  chmod 755 ${TARGET_DIRECTORY}/darwin/Distribution
+  cp -r "$SCRIPTPATH/darwin" "${TARGET_DIRECTORY}/"
+  chmod -R 755 "${TARGET_DIRECTORY}/darwin/scripts"
+  chmod -R 755 "${TARGET_DIRECTORY}/darwin/Resources"
+  chmod 755 "${TARGET_DIRECTORY}/darwin/Distribution"
 }
 
 copyBuildDirectory() {
-    sed -i '' -e 's/__VERSION__/'${VERSION}'/g' ${TARGET_DIRECTORY}/darwin/scripts/postinstall
-    sed -i '' -e 's/__PRODUCT__/'${PRODUCT}'/g' ${TARGET_DIRECTORY}/darwin/scripts/postinstall
-    chmod -R 755 ${TARGET_DIRECTORY}/darwin/scripts/postinstall
+    sed -i '' -e 's/__VERSION__/'${VERSION}'/g' "${TARGET_DIRECTORY}/darwin/scripts/postinstall"
+    sed -i '' -e 's/__PRODUCT__/'${PRODUCT}'/g' "${TARGET_DIRECTORY}/darwin/scripts/postinstall"
+    chmod -R 755 "${TARGET_DIRECTORY}/darwin/scripts/postinstall"
 
-    sed -i '' -e 's/__VERSION__/'${VERSION}'/g' ${TARGET_DIRECTORY}/darwin/Distribution
-    sed -i '' -e 's/__PRODUCT__/'${PRODUCT}'/g' ${TARGET_DIRECTORY}/darwin/Distribution
-    chmod -R 755 ${TARGET_DIRECTORY}/darwin/Distribution
+    sed -i '' -e 's/__VERSION__/'${VERSION}'/g' "${TARGET_DIRECTORY}/darwin/Distribution"
+    sed -i '' -e 's/__PRODUCT__/'${PRODUCT}'/g' "${TARGET_DIRECTORY}/darwin/Distribution"
+    chmod -R 755 "${TARGET_DIRECTORY}/darwin/Distribution"
 
-    sed -i '' -e 's/__VERSION__/'${VERSION}'/g' ${TARGET_DIRECTORY}/darwin/Resources/*.html
-    sed -i '' -e 's/__PRODUCT__/'${PRODUCT}'/g' ${TARGET_DIRECTORY}/darwin/Resources/*.html
-    chmod -R 755 ${TARGET_DIRECTORY}/darwin/Resources/
+    sed -i '' -e 's/__VERSION__/'${VERSION}'/g' "${TARGET_DIRECTORY}"/darwin/Resources/*.html
+    sed -i '' -e 's/__PRODUCT__/'${PRODUCT}'/g' "${TARGET_DIRECTORY}"/darwin/Resources/*.html
+    chmod -R 755 "${TARGET_DIRECTORY}/darwin/Resources/"
 
-    rm -rf ${TARGET_DIRECTORY}/darwinpkg
-    mkdir -p ${TARGET_DIRECTORY}/darwinpkg
+    rm -rf "${TARGET_DIRECTORY}/darwinpkg"
+    mkdir -p "${TARGET_DIRECTORY}/darwinpkg"
 
     #Copy cellery product to /Library/Cellery
-    mkdir -p ${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}
-    cp -a $SCRIPTPATH/application/. ${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}
-    chmod -R 755 ${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}
+    mkdir -p "${TARGET_DIRECTORY}"/darwinpkg/Library/${PRODUCT}/${VERSION}
+    cp -a "$SCRIPTPATH"/application/. "${TARGET_DIRECTORY}"/darwinpkg/Library/${PRODUCT}/${VERSION}
+    chmod -R 755 "${TARGET_DIRECTORY}"/darwinpkg/Library/${PRODUCT}/${VERSION}
 
-    rm -rf ${TARGET_DIRECTORY}/package
-    mkdir -p ${TARGET_DIRECTORY}/package
-    chmod -R 755 ${TARGET_DIRECTORY}/package
+    rm -rf "${TARGET_DIRECTORY}/package"
+    mkdir -p "${TARGET_DIRECTORY}/package"
+    chmod -R 755 "${TARGET_DIRECTORY}/package"
 
-    rm -rf ${TARGET_DIRECTORY}/pkg
-    mkdir -p ${TARGET_DIRECTORY}/pkg
-    chmod -R 755 ${TARGET_DIRECTORY}/pkg
+    rm -rf "${TARGET_DIRECTORY}/pkg"
+    mkdir -p "${TARGET_DIRECTORY}/pkg"
+    chmod -R 755 "${TARGET_DIRECTORY}/pkg"
 }
 
 function buildPackage() {
     log_info "Apllication installer package building started.(1/3)"
-    pkgbuild --identifier org.${PRODUCT}.${VERSION} \
-    --version ${VERSION} \
-    --scripts ${TARGET_DIRECTORY}/darwin/scripts \
-    --root ${TARGET_DIRECTORY}/darwinpkg \
-    ${TARGET_DIRECTORY}/package/${PRODUCT}.pkg > /dev/null 2>&1
+    pkgbuild --identifier "org.${PRODUCT}.${VERSION}" \
+    --version "${VERSION}" \
+    --scripts "${TARGET_DIRECTORY}/darwin/scripts" \
+    --root "${TARGET_DIRECTORY}/darwinpkg" \
+    "${TARGET_DIRECTORY}/package/${PRODUCT}.pkg" > /dev/null 2>&1
 }
 
 function buildProduct() {
     log_info "Application installer product building started.(2/3)"
-    productbuild --distribution ${TARGET_DIRECTORY}/darwin/Distribution \
-    --resources ${TARGET_DIRECTORY}/darwin/Resources \
-    --package-path ${TARGET_DIRECTORY}/package \
-    ${TARGET_DIRECTORY}/pkg/$1 > /dev/null 2>&1
+    productbuild --distribution "${TARGET_DIRECTORY}/darwin/Distribution" \
+    --resources "${TARGET_DIRECTORY}/darwin/Resources" \
+    --package-path "${TARGET_DIRECTORY}/package" \
+    "${TARGET_DIRECTORY}/pkg/$1" > /dev/null 2>&1
 }
 
 function signProduct() {
     log_info "Application installer signing process started.(3/3)"
-    mkdir -p ${TARGET_DIRECTORY}/pkg-signed
-    chmod -R 755 ${TARGET_DIRECTORY}/pkg-signed
+    mkdir -pv "${TARGET_DIRECTORY}/pkg-signed"
+    chmod -R 755 "${TARGET_DIRECTORY}/pkg-signed"
 
     read -p "Please enter the Apple Developer Installer Certificate ID:" APPLE_DEVELOPER_CERTIFICATE_ID
     productsign --sign "Developer ID Installer: ${APPLE_DEVELOPER_CERTIFICATE_ID}" \
-    ${TARGET_DIRECTORY}/pkg/$1 \
-    ${TARGET_DIRECTORY}/pkg-signed/$1
+    "${TARGET_DIRECTORY}/pkg/$1" \
+    "${TARGET_DIRECTORY}/pkg-signed/$1"
 
-    pkgutil --check-signature ${TARGET_DIRECTORY}/pkg-signed/$1
+    pkgutil --check-signature "${TARGET_DIRECTORY}/pkg-signed/$1"
 }
 
 function createInstaller() {
@@ -175,7 +175,7 @@ function createInstaller() {
 }
 
 function createUninstaller(){
-    cp $SCRIPTPATH/darwin/Resources/uninstall.sh ${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}
+    cp "$SCRIPTPATH/darwin/Resources/uninstall.sh" "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}"
     sed -i '' -e "s/__VERSION__/${VERSION}/g" "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/uninstall.sh"
     sed -i '' -e "s/__PRODUCT__/${PRODUCT}/g" "${TARGET_DIRECTORY}/darwinpkg/Library/${PRODUCT}/${VERSION}/uninstall.sh"
 }


### PR DESCRIPTION
Proposed Fix for #18 

Allow script to run from any folder, even if it has spaces in its path:
`/Users/axemasta/Documents/GitHub/Spacey Folder Lmao/macos-installer-builder/macOS-x64`

Running the script from the above location before:
```
axemasta@Axemastas-MacBook-Pro macOS-x64 % ./build-macos-x64.sh CoolAppBro 1.0.0
cat: /Users/axemasta/Documents/GitHub/Spacey: No such file or directory
cat: Folder: No such file or directory
cat: Lmao/macos-installer-builder/macOS-x64/utils/ascii_art.txt: No such file or directory

Application Name : CoolAppBro
Application Version : 1.0.0
[2021-08-12 11:01:26][INFO] Installer generating process started.
./build-macos-x64.sh: line 84: [: too many arguments
mkdir: Lmao/macos-installer-builder/macOS-x64: No such file or directory
[2021-08-12 11:01:26][ERROR] Failed to create /Users/axemasta/Documents/GitHub/Spacey Folder Lmao/macos-installer-builder/macOS-x64/target directory
```

Running the script after:
```
axemasta@Axemastas-MacBook-Pro macOS-x64 % pwd                                  
/Users/axemasta/Documents/GitHub/Spacey Folder Lmao/macos-installer-builder/macOS-x64
axemasta@Axemastas-MacBook-Pro macOS-x64 % ./build-macos-x64.sh CoolAppBro 1.0.0
                                   ___           _        _ _
 _ __ ___   __ _  ___ ___  ___    |_ _|_ __  ___| |_ __ _| | | ___ _ __
| '_ ` _ \ / _` |/ __/ _ \/ __|    | || '_ \/ __| __/ _` | | |/ _ \ '__|
| | | | | | (_| | (_| (_) \__ \    | || | | \__ \ || (_| | | |  __/ |
|_|_|_| |_|\__,_|\___\___/|___/   |___|_| |_|___/\__\__,_|_|_|\___|_|

                 ____        _ _     _
                | __ ) _   _(_) | __| | ___ _ __
                |  _ \| | | | | |/ _` |/ _ \ '__|
                | |_) | |_| | | | (_| |  __/ |
                |____/ \__,_|_|_|\__,_|\___|_|                                        

Application Name : CoolAppBro
Application Version : 1.0.0
[2021-08-12 11:38:50][INFO] Installer generating process started.
[2021-08-12 11:38:50][INFO] Cleaning /Users/axemasta/Documents/GitHub/Spacey Folder Lmao/macos-installer-builder/macOS-x64/target directory.
[2021-08-12 11:38:50][INFO] Application installer generation process started.(3 Steps)
[2021-08-12 11:38:50][INFO] Application installer package building started.(1/3)
[2021-08-12 11:38:50][INFO] Application installer product building started.(2/3)
Do you wish to sign the installer (You should have Apple Developer Certificate) [y/N]?n
[2021-08-12 11:38:50][INFO] Skipped signing process.
[2021-08-12 11:38:50][INFO] Application installer generation steps finished.
[2021-08-12 11:38:50][INFO] Installer generating process finished
```

I've also included some housekeeping for the odd misspelling 😁